### PR TITLE
Add Stylua Support for Lua Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ This makes reform.nvim ideal for lazy loading configurations with plugin manager
 - `clang-format` for C family (C, C++).
 - `stylua` for Lua files.
 
+### Stylua Configuration
+
+Stylua automatically detects configuration files in your project:
+
+- **`.stylua.toml`** (recommended)
+- **`stylua.toml`** (alternative)
+
+Configuration files are searched for in:
+- Current working directory
+- Parent directories up to the project root
+- User home directory as fallback
+
+Example `.stylua.toml`:
+```toml
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+```
+
 **This project is still under development, please use with caution**
 **Report any bugs or ideas you found in Issue :)**
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is inspired by [vim-rt-format](https://github.com/skywind3000/vim-r
 - Nvim with "+python3" feature
 - Python module "autopep8"
 - A `clang-format` executable installed
+- `stylua` executable for Lua formatting
 
 ## Installation
 
@@ -83,7 +84,8 @@ require("reform").setup({
   formatters = {
     python = 'autopep8',
     c = 'clang-format',
-    cpp = 'clang-format'
+    cpp = 'clang-format',
+    lua = 'stylua'
   },
   debug = false
 })
@@ -104,8 +106,9 @@ This makes reform.nvim ideal for lazy loading configurations with plugin manager
 
 `reform.nvim` currently supports the following formatters:
 
-- `autopep8` from Python3, for Python, Lua, Java, JavaScript, JSON, ActionScript, Ruby.
+- `autopep8` from Python3, for Python, Java, JavaScript, JSON, ActionScript, Ruby.
 - `clang-format` for C family (C, C++).
+- `stylua` for Lua files.
 
 **This project is still under development, please use with caution**
 **Report any bugs or ideas you found in Issue :)**

--- a/docs/formatter-configuration.md
+++ b/docs/formatter-configuration.md
@@ -72,15 +72,35 @@ require('reform').setup({
   formatters = {
     paths = {
       ["ruff"] = vim.fn.stdpath("data") .. "/mason/bin/ruff",
-      ["clang-format"] = vim.fn.stdpath("data") .. "/mason/bin/clang-format"
+      ["clang-format"] = vim.fn.stdpath("data") .. "/mason/bin/clang-format",
+      ["stylua"] = vim.fn.stdpath("data") .. "/mason/bin/stylua"
     },
     languages = {
       python = "ruff",
       c = "clang-format",
-      cpp = "clang-format"
+      cpp = "clang-format",
+      lua = "stylua"
     }
   }
 })
+```
+
+### Stylua Configuration
+
+Stylua supports configuration through TOML files. The formatter will automatically detect:
+
+- `.stylua.toml` in project root
+- `stylua.toml` in project root  
+- Configuration files in parent directories
+
+Example `.stylua.toml`:
+```toml
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
 ```
 
 ## Implementation Plan

--- a/lua/reform/config.lua
+++ b/lua/reform/config.lua
@@ -25,6 +25,7 @@ local defaults = {
     python = "autopep8",
     c = "clang-format",
     cpp = "clang-format",
+    lua = "stylua",
   },
   debug = false, -- Enable debug info
 }

--- a/lua/reform/formatters.lua
+++ b/lua/reform/formatters.lua
@@ -13,8 +13,8 @@ local formatter_classes = {
   c = "reform.formatters.clang",
   cpp = "reform.formatters.clang",
   ["c++"] = "reform.formatters.clang",
-  -- Legacy support - use Python formatter for other languages
-  lua = "reform.formatters.python",
+  -- Use Stylua for Lua files
+  lua = "reform.formatters.stylua",
   java = "reform.formatters.python",
   javascript = "reform.formatters.python",
   json = "reform.formatters.python",

--- a/lua/reform/formatters/stylua.lua
+++ b/lua/reform/formatters/stylua.lua
@@ -46,15 +46,28 @@ function StyluaFormatter:format(text, filetype)
     return text
   end
 
-  -- Use stylua for formatting via stdin
-  local cmd = "stylua -"
-  
-  local result = vim.fn.system(cmd, text)
-  if vim.v.shell_error == 0 then
-    return vim.trim(result)
+  -- Look for .stylua.toml in project root and parent directories
+  local config_path = vim.fn.findfile(".stylua.toml", ".;")
+  if config_path == "" then
+    -- Also check for stylua.toml (without dot)
+    config_path = vim.fn.findfile("stylua.toml", ".;")
   end
 
-  return text
+  -- Build command with proper argument structure
+  local cmd = {"stylua", "-"}
+  if config_path ~= "" then
+    table.insert(cmd, 2, "--config-path")
+    table.insert(cmd, 3, config_path)
+  end
+  
+  local result = vim.fn.system(cmd, text)
+  
+  if vim.v.shell_error ~= 0 then
+    vim.notify("Reform: Stylua formatting failed", vim.log.levels.WARN)
+    return text
+  end
+  
+  return vim.trim(result)
 end
 
 return StyluaFormatter

--- a/lua/reform/formatters/stylua.lua
+++ b/lua/reform/formatters/stylua.lua
@@ -1,0 +1,60 @@
+local BaseFormatter = require("reform.formatters.base")
+
+---@class StyluaFormatter : BaseFormatter
+---@field _availability_cache table|nil
+local StyluaFormatter = setmetatable({}, { __index = BaseFormatter })
+StyluaFormatter.__index = StyluaFormatter
+
+--- Create a new StyluaFormatter instance
+---@return StyluaFormatter
+function StyluaFormatter:new()
+  local instance = setmetatable({}, self)
+  instance._availability_cache = nil
+  return instance
+end
+
+--- Check if the Stylua formatter is available (with caching)
+---@return boolean
+---@return string|nil error_message
+function StyluaFormatter:is_available()
+  -- Return cached result if available
+  if self._availability_cache ~= nil then
+    return self._availability_cache.result, self._availability_cache.error
+  end
+
+  -- Cache the result
+  self._availability_cache = {}
+
+  local result = vim.fn.executable("stylua")
+  if result == 0 then
+    self._availability_cache.result = false
+    self._availability_cache.error = "stylua not found in PATH"
+    return self._availability_cache.result, self._availability_cache.error
+  end
+
+  self._availability_cache.result = true
+  self._availability_cache.error = nil
+  return self._availability_cache.result, self._availability_cache.error
+end
+
+--- Format Lua code using stylua
+---@param text string The text to format
+---@param filetype string|nil The filetype of the text
+---@return string The formatted text
+function StyluaFormatter:format(text, filetype)
+  if text == "" then
+    return text
+  end
+
+  -- Use stylua for formatting via stdin
+  local cmd = "stylua -"
+  
+  local result = vim.fn.system(cmd, text)
+  if vim.v.shell_error == 0 then
+    return vim.trim(result)
+  end
+
+  return text
+end
+
+return StyluaFormatter


### PR DESCRIPTION
This PR adds full Stylua support to reform.nvim, replacing the previous Python formatter fallback for Lua files.

## Changes
- Created new Stylua formatter module (lua/reform/formatters/stylua.lua)
- Updated formatter registry to use Stylua for Lua files
- Updated configuration defaults to include Stylua for Lua
- Updated documentation with Stylua requirements and usage

## Benefits
- Proper Lua code formatting using dedicated formatter
- Maintains existing functionality and API
- Follows established patterns in the codebase

Fixes #4

---

🤖 Generated with [Claude Code](https://claude.ai/code)